### PR TITLE
Autogenerate library

### DIFF
--- a/.github/workflows/generate_publish_release.yml
+++ b/.github/workflows/generate_publish_release.yml
@@ -1,0 +1,96 @@
+name: Generate Publish Release
+
+on:
+  repository_dispatch:
+    types: [generate_publish_release]
+
+jobs:
+  Generate:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-node@v3
+      - uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: 3.1
+      - name: Bump version
+        id: bump_version
+        run: echo "::set-output name=version::$(ruby .github/version.rb ${{ github.event.client_payload.version }})"
+
+      - name: Clean repo
+        run: ruby .github/clean.rb
+
+      - name: Install openapi-generator-cli
+        run: |
+          npm install @openapitools/openapi-generator-cli -g
+          openapi-generator-cli version-manager set 5.4.0
+      - run: |
+          openapi-generator-cli generate \
+            -i https://raw.githubusercontent.com/mxenabled/openapi/master/openapi/mx_platform_api.yml \
+            -g java \
+            -c ./openapi/config.yml \
+            -t ./openapi/templates
+
+      - name: Checkout master
+        run: git checkout master
+
+      - name: Create commit
+        run: |
+          git config user.name "devexperience"
+          git config user.email "devexperience@mx.com"
+          git add .
+          git commit -m "Generated version ${{ steps.bump_version.outputs.version }}
+
+          This commit was automatically created by a GitHub Action to generate version ${{ steps.bump_version.outputs.version }} of this library."
+
+      - name: Push to master
+        run: git push origin master
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+  Publish:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: Set up JDK 11
+        uses: actions/setup-java@v2
+        with:
+          distribution: 'temurin'
+          java-version: '11'
+
+      - name: Build with Maven
+        run: mvn -B package --file pom.xml
+
+      - name: Set up Apache Maven Central
+        uses: actions/setup-java@v2
+        with:
+          distribution: 'temurin'
+          java-version: '11'
+          server-id: ossrh
+          server-username: MAVEN_USERNAME
+          server-password: MAVEN_CENTRAL_TOKEN
+          gpg-private-key: ${{ secrets.MAVEN_GPG_PRIVATE_KEY }}
+          gpg-passphrase: MAVEN_GPG_PASSPHRASE
+
+      - name: Publish to Apache Maven Central
+        run: mvn deploy -P sign-artifacts
+        env:
+          MAVEN_USERNAME: ${{ secrets.MAVEN_USERNAME }}
+          MAVEN_CENTRAL_TOKEN: ${{ secrets.MAVEN_CENTRAL_TOKEN }}
+          MAVEN_GPG_PASSPHRASE: ${{ secrets.MAVEN_GPG_PASSPHRASE }}
+  Release:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: Set up Ruby
+        uses: ruby/setup-ruby@v1
+        with:
+          bundler-cache: true
+          ruby-version: 3.1
+      - name: Read version
+        id: read_version
+        run: echo "::set-output name=version::$(ruby .github/version.rb)"
+      - name: Create tag and release
+        run: |
+          gh release create "v${{ steps.read_version.outputs.version }}"
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Ref: mxenabled/openapi#104

Created a `repository_dispatch` event workflow that will be used to generate, publish, and release this library.

The workflow will accept a request from the openapi repo where the body of the request includes the version bump (major, minor, patch). This will allow us to generate and publish a new version of library when changes are made to the openapi spec.