### PR TITLE
Add test dependency

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -16,7 +16,7 @@ jobs:
       uses: actions/setup-java@v3
       with:
         distribution: 'temurin'
-        java-version: '17'
+        java-version: '11'
 
     - name: Build with Maven
       run: mvn -B package --file pom.xml
@@ -25,7 +25,7 @@ jobs:
       uses: actions/setup-java@v3
       with:
         distribution: 'temurin'
-        java-version: '17'
+        java-version: '11'
         server-id: ossrh
         server-username: MAVEN_USERNAME
         server-password: MAVEN_CENTRAL_TOKEN

--- a/openapi/templates/pom.mustache
+++ b/openapi/templates/pom.mustache
@@ -329,6 +329,12 @@
         </dependency>
         <!-- test dependencies -->
         <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-api</artifactId>
+            <version>${junit-jupiter-version}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
             <groupId>junit</groupId>
             <artifactId>junit</artifactId>
             <version>${junit-version}</version>


### PR DESCRIPTION
Adds the `junit-jupiter-api` test dependency to fix the maven build.

This also reverts back to using Java 11 in our publish workflow.