### PR TITLE
Update publish workflow

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -5,15 +5,16 @@ on:
     branches: [master]
   repository_dispatch:
     types: [publish_sdk]
+  workflow_dispatch:
 
 jobs:
   Publish:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
     - name: Set up JDK 11
-      uses: actions/setup-java@v3
+      uses: actions/setup-java@v4
       with:
         distribution: 'temurin'
         java-version: '11'
@@ -22,7 +23,7 @@ jobs:
       run: mvn -B package --file pom.xml
 
     - name: Set up Apache Maven Central
-      uses: actions/setup-java@v3
+      uses: actions/setup-java@v4
       with:
         distribution: 'temurin'
         java-version: '11'


### PR DESCRIPTION
There were some recent updates to the [action](https://github.com/actions/setup-java) we use to publish the library. These updates could have a potential impact on our workflow.

This also includes the ability to manually run the publish workflow using a `workflow_dispatch` command.